### PR TITLE
Add handle get players

### DIFF
--- a/cmd/switcher/main.go
+++ b/cmd/switcher/main.go
@@ -78,8 +78,13 @@ func main() {
 	mux.HandleFunc("POST /games", gameHandlers.HandleCreateGame)
 	mux.HandleFunc("GET /games", gameHandlers.HandleGetGames)
 	mux.HandleFunc("GET /games/{gameID}", gameHandlers.HandleGetGameByID)
-	mux.HandleFunc("PATCH /games/start/{gameID}", gameStateHandlers.HandleStartGame)
+	mux.HandleFunc("PATCH /game_state/start/{gameID}", gameStateHandlers.HandleStartGame)
+	// Player routes
 	mux.HandleFunc("POST /players/join/{gameID}", playerHandlers.HandleJoinGame)
+	mux.HandleFunc("GET /players/{gameID}", playerHandlers.HandleGetPlayers)
+	mux.HandleFunc("GET /players/{gameID}/{playerID}", playerHandlers.HandleGetPlayer)
+
+	// Websocket route
 	mux.HandleFunc("/ws", wsHandlers.HandleWebSocket)
 
 	// Add middleware

--- a/internal/database/players.sql.go
+++ b/internal/database/players.sql.go
@@ -81,11 +81,16 @@ func (q *Queries) CreatePlayer(ctx context.Context, arg CreatePlayerParams) (Pla
 const getPlayerByID = `-- name: GetPlayerByID :one
 SELECT id, name, turn, game_id, game_state_id, host, winner, created_at, updated_at
 FROM players
-WHERE id=$1
+WHERE game_id=$1 AND id=$2
 `
 
-func (q *Queries) GetPlayerByID(ctx context.Context, id uuid.UUID) (Player, error) {
-	row := q.db.QueryRowContext(ctx, getPlayerByID, id)
+type GetPlayerByIDParams struct {
+	GameID uuid.UUID
+	ID     uuid.UUID
+}
+
+func (q *Queries) GetPlayerByID(ctx context.Context, arg GetPlayerByIDParams) (Player, error) {
+	row := q.db.QueryRowContext(ctx, getPlayerByID, arg.GameID, arg.ID)
 	var i Player
 	err := row.Scan(
 		&i.ID,
@@ -101,14 +106,14 @@ func (q *Queries) GetPlayerByID(ctx context.Context, id uuid.UUID) (Player, erro
 	return i, err
 }
 
-const getPlayers = `-- name: GetPlayers :many
+const getPlayersInGame = `-- name: GetPlayersInGame :many
 SELECT id, name, turn, game_id, game_state_id, host, winner, created_at, updated_at
 FROM players
 WHERE game_id=$1
 `
 
-func (q *Queries) GetPlayers(ctx context.Context, gameID uuid.UUID) ([]Player, error) {
-	rows, err := q.db.QueryContext(ctx, getPlayers, gameID)
+func (q *Queries) GetPlayersInGame(ctx context.Context, gameID uuid.UUID) ([]Player, error) {
+	rows, err := q.db.QueryContext(ctx, getPlayersInGame, gameID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/figureCard/service.go
+++ b/internal/figureCard/service.go
@@ -55,7 +55,7 @@ func (s *Service) CreateFigureCardDeck(ctx context.Context, gameID uuid.UUID) er
 		}
 	}
 
-	players, err := s.playerRepo.GetPlayers(ctx, gameID)
+	players, err := s.playerRepo.GetPlayersInGame(ctx, gameID)
 	if err != nil {
 		return fmt.Errorf("failed to get players: %w", err)
 	}

--- a/internal/handlers/handle_get_players.go
+++ b/internal/handlers/handle_get_players.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/NachoGz/switcher-backend-go/internal/utils"
+	"github.com/google/uuid"
+)
+
+func (h *PlayerHandlers) HandleGetPlayers(w http.ResponseWriter, r *http.Request) {
+	gameID, err := uuid.Parse(r.PathValue("gameID"))
+	if err != nil {
+		utils.RespondWithError(w, http.StatusBadRequest, "Couldn't parse game ID", err)
+		return
+	}
+
+	log.Println("Getting players from game: ", gameID)
+
+	players, err := h.playerService.GetPlayersInGame(context.Background(), gameID)
+	if err != nil {
+		utils.RespondWithError(w, http.StatusInternalServerError, "failed to fetch players", err)
+		return
+	}
+
+	utils.RespondWithJSON(w, http.StatusOK, players)
+}
+
+func (h *PlayerHandlers) HandleGetPlayer(w http.ResponseWriter, r *http.Request) {
+	gameID, err := uuid.Parse(r.PathValue("gameID"))
+	if err != nil {
+		utils.RespondWithError(w, http.StatusBadRequest, "Couldn't parse game ID", err)
+		return
+	}
+
+	playerID, err := uuid.Parse(r.PathValue("playerID"))
+	if err != nil {
+		utils.RespondWithError(w, http.StatusBadRequest, "Couldn't parse player ID", err)
+		return
+	}
+
+	log.Printf("Getting player %s from game %s: ", playerID, gameID)
+
+	player, err := h.playerService.GetPlayerByID(context.Background(), gameID, playerID)
+	if err != nil {
+		utils.RespondWithError(w, http.StatusInternalServerError, "failed to fetch player", err)
+		return
+	}
+
+	utils.RespondWithJSON(w, http.StatusOK, player)
+}

--- a/internal/handlers/handle_get_players_test.go
+++ b/internal/handlers/handle_get_players_test.go
@@ -1,0 +1,321 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	game_mock "github.com/NachoGz/switcher-backend-go/internal/game/mocks"
+	gameState_mock "github.com/NachoGz/switcher-backend-go/internal/game_state/mocks"
+	"github.com/NachoGz/switcher-backend-go/internal/handlers"
+	"github.com/NachoGz/switcher-backend-go/internal/player"
+	player_mock "github.com/NachoGz/switcher-backend-go/internal/player/mocks"
+	websocket_mock "github.com/NachoGz/switcher-backend-go/internal/websocket/mocks"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestHandleGetPlayer_Success(t *testing.T) {
+	// Setup mock service
+	mockPlayerService := new(player_mock.MockPlayerService)
+	mockGameService := new(game_mock.MockGameService)
+	mockGameStateService := new(gameState_mock.MockGameStateService)
+	mockWSHub := new(websocket_mock.MockWebSocketHub)
+
+	// Create test games
+	gameID := uuid.New()
+	gameStateID := uuid.New()
+
+	responsePlayers := []player.Player{
+		{
+			ID:          uuid.New(),
+			Name:        "Test Player 1",
+			Host:        true,
+			GameID:      gameID,
+			GameStateID: gameStateID,
+		},
+		{
+			ID:          uuid.New(),
+			Name:        "Test Player 2",
+			Host:        false,
+			GameID:      gameID,
+			GameStateID: gameStateID,
+		},
+	}
+	// Set up mock expectations
+	mockPlayerService.On("GetPlayersInGame", mock.Anything, gameID).
+		Return(responsePlayers, nil)
+
+	// Create handlers
+	handlers := handlers.NewPlayerHandlers(mockPlayerService, mockGameService, mockGameStateService, mockWSHub)
+
+	// Create request without query parameters
+	req, _ := http.NewRequest(http.MethodGet, "/players/", nil)
+	req.SetPathValue("gameID", gameID.String())
+	rr := httptest.NewRecorder()
+
+	// Call handler
+	handlers.HandleGetPlayers(rr, req)
+
+	// Check response
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var response []player.Player
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	// Verify response structure
+	assert.Equal(t, response, responsePlayers)
+
+	// Verify player array
+	assert.Equal(t, 2, len(responsePlayers))
+
+	// Verift mock was called
+	mockPlayerService.AssertExpectations(t)
+}
+
+func TestHandleGetPlayers_InvalidGameID(t *testing.T) {
+	// Setup mock service
+	mockPlayerService := new(player_mock.MockPlayerService)
+	mockGameService := new(game_mock.MockGameService)
+	mockGameStateService := new(gameState_mock.MockGameStateService)
+	mockWSHub := new(websocket_mock.MockWebSocketHub)
+
+	// Create handlers
+	handlers := handlers.NewPlayerHandlers(mockPlayerService, mockGameService, mockGameStateService, mockWSHub)
+
+	// Create request without query parameters
+	req, _ := http.NewRequest(http.MethodGet, "/players/", nil)
+	req.SetPathValue("gameID", "invalid-id")
+	rr := httptest.NewRecorder()
+
+	// Call handler
+	handlers.HandleGetPlayers(rr, req)
+
+	// Check response
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	// Check response
+	var response map[string]interface{}
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	// Verify error message
+	assert.Contains(t, response, "error")
+	assert.Equal(t, "Couldn't parse game ID", response["error"])
+
+	// Verify mock was called
+	mockPlayerService.AssertNotCalled(t, "GetPlayersInGame")
+}
+
+func TestHandleGetPlayers_ServiceError(t *testing.T) {
+	// Setup mock service
+	mockPlayerService := new(player_mock.MockPlayerService)
+	mockGameService := new(game_mock.MockGameService)
+	mockGameStateService := new(gameState_mock.MockGameStateService)
+	mockWSHub := new(websocket_mock.MockWebSocketHub)
+
+	// Test data
+	gameID := uuid.New()
+
+	// Setup expectations
+	mockPlayerService.On("GetPlayersInGame", mock.Anything, gameID).
+		Return([]player.Player{}, errors.New("error fetching players"))
+
+	// Create handlers
+	handlers := handlers.NewPlayerHandlers(mockPlayerService, mockGameService, mockGameStateService, mockWSHub)
+
+	// Create request without query parameters
+	req, _ := http.NewRequest(http.MethodGet, "/players/", nil)
+	req.SetPathValue("gameID", gameID.String())
+	rr := httptest.NewRecorder()
+
+	// Call handler
+	handlers.HandleGetPlayers(rr, req)
+
+	// Check response
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	// Check response
+	var response map[string]interface{}
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	// Verify error message
+	assert.Contains(t, response, "error")
+	assert.Equal(t, "failed to fetch players", response["error"])
+
+	// Verify mock was called
+	mockPlayerService.AssertExpectations(t)
+}
+
+func TestHandleGetPlayerByID_Success(t *testing.T) {
+	// Setup mock service
+	mockPlayerService := new(player_mock.MockPlayerService)
+	mockGameService := new(game_mock.MockGameService)
+	mockGameStateService := new(gameState_mock.MockGameStateService)
+	mockWSHub := new(websocket_mock.MockWebSocketHub)
+
+	// Create test games
+	gameID := uuid.New()
+	playerID := uuid.New()
+	gameStateID := uuid.New()
+
+	responsePlayer := player.Player{
+		ID:          playerID,
+		Name:        "Test Player",
+		Host:        true,
+		GameID:      gameID,
+		GameStateID: gameStateID,
+	}
+	// Set up mock expectations
+	mockPlayerService.On("GetPlayerByID", mock.Anything, gameID, playerID).
+		Return(responsePlayer, nil)
+
+	// Create handlers
+	handlers := handlers.NewPlayerHandlers(mockPlayerService, mockGameService, mockGameStateService, mockWSHub)
+
+	// Create request without query parameters
+	req, _ := http.NewRequest(http.MethodGet, "/players/", nil)
+	req.SetPathValue("gameID", gameID.String())
+	req.SetPathValue("playerID", playerID.String())
+	rr := httptest.NewRecorder()
+
+	// Call handler
+	handlers.HandleGetPlayer(rr, req)
+
+	// Check response
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var response player.Player
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	// Verify response structure
+	assert.Equal(t, response, responsePlayer)
+
+	// Verift mock was called
+	mockPlayerService.AssertExpectations(t)
+}
+
+func TestHandleGetGamesByID_InvalidGameID(t *testing.T) {
+	// Setup mock service
+	mockPlayerService := new(player_mock.MockPlayerService)
+	mockGameService := new(game_mock.MockGameService)
+	mockGameStateService := new(gameState_mock.MockGameStateService)
+	mockWSHub := new(websocket_mock.MockWebSocketHub)
+
+	// Test data
+	playerID := uuid.New()
+
+	// Create handlers
+	handlers := handlers.NewPlayerHandlers(mockPlayerService, mockGameService, mockGameStateService, mockWSHub)
+
+	// Create request without query parameters
+	req, _ := http.NewRequest(http.MethodGet, "/players/", nil)
+	req.SetPathValue("gameID", "invalid-id")
+	req.SetPathValue("playerID", playerID.String())
+	rr := httptest.NewRecorder()
+
+	// Call handler
+	handlers.HandleGetPlayer(rr, req)
+
+	// Check response
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	// Check response
+	var response map[string]interface{}
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	// Verify error message
+	assert.Contains(t, response, "error")
+	assert.Equal(t, "Couldn't parse game ID", response["error"])
+
+	// Verify mock was called
+	mockPlayerService.AssertNotCalled(t, "GetPlayerByID")
+}
+
+func TestHandleGetGamesByID_InvalidPlayerID(t *testing.T) {
+	// Setup mock service
+	mockPlayerService := new(player_mock.MockPlayerService)
+	mockGameService := new(game_mock.MockGameService)
+	mockGameStateService := new(gameState_mock.MockGameStateService)
+	mockWSHub := new(websocket_mock.MockWebSocketHub)
+
+	// Test data
+	gameID := uuid.New()
+
+	// Create handlers
+	handlers := handlers.NewPlayerHandlers(mockPlayerService, mockGameService, mockGameStateService, mockWSHub)
+
+	// Create request without query parameters
+	req, _ := http.NewRequest(http.MethodGet, "/players/", nil)
+	req.SetPathValue("gameID", gameID.String())
+	req.SetPathValue("playerID", "invalid-id")
+	rr := httptest.NewRecorder()
+
+	// Call handler
+	handlers.HandleGetPlayer(rr, req)
+
+	// Check response
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	// Check response
+	var response map[string]interface{}
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	// Verify error message
+	assert.Contains(t, response, "error")
+	assert.Equal(t, "Couldn't parse player ID", response["error"])
+
+	// Verify mock was called
+	mockPlayerService.AssertNotCalled(t, "GetPlayerByID")
+}
+
+func TestHandleGetPlayerByID_ServiceError(t *testing.T) {
+	// Setup mock service
+	mockPlayerService := new(player_mock.MockPlayerService)
+	mockGameService := new(game_mock.MockGameService)
+	mockGameStateService := new(gameState_mock.MockGameStateService)
+	mockWSHub := new(websocket_mock.MockWebSocketHub)
+
+	// Create test games
+	gameID := uuid.New()
+	playerID := uuid.New()
+
+	// Set up mock expectations
+	mockPlayerService.On("GetPlayerByID", mock.Anything, gameID, playerID).
+		Return(player.Player{}, errors.New("error getting player"))
+
+	// Create handlers
+	handlers := handlers.NewPlayerHandlers(mockPlayerService, mockGameService, mockGameStateService, mockWSHub)
+
+	// Create request without query parameters
+	req, _ := http.NewRequest(http.MethodGet, "/players/", nil)
+	req.SetPathValue("gameID", gameID.String())
+	req.SetPathValue("playerID", playerID.String())
+	rr := httptest.NewRecorder()
+
+	// Call handler
+	handlers.HandleGetPlayer(rr, req)
+
+	// Check response
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	// Check response
+	var response map[string]interface{}
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	// Verify error message
+	assert.Contains(t, response, "error")
+	assert.Equal(t, "failed to fetch player", response["error"])
+
+	// Verift mock was called
+	mockPlayerService.AssertExpectations(t)
+}

--- a/internal/handlers/handle_start_game.go
+++ b/internal/handlers/handle_start_game.go
@@ -26,7 +26,7 @@ func (h *GameStateHandlers) HandleStartGame(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	players, err := h.playerService.GetPlayers(context.Background(), gameID)
+	players, err := h.playerService.GetPlayersInGame(context.Background(), gameID)
 	if err != nil {
 		utils.RespondWithError(w, http.StatusInternalServerError, "Error fetching players", err)
 		return

--- a/internal/handlers/handle_start_game_test.go
+++ b/internal/handlers/handle_start_game_test.go
@@ -56,7 +56,7 @@ func TestHandleStartGame_Success(t *testing.T) {
 	mockGameStateService.On("UpdateGameState", mock.Anything, gameID, gameState.PLAYING).
 		Return(nil)
 
-	mockPlayerService.On("GetPlayers", mock.Anything, gameID).
+	mockPlayerService.On("GetPlayersInGame", mock.Anything, gameID).
 		Return(responsePlayers, nil)
 
 	mockPlayerService.On("AssignRandomTurns", mock.Anything, responsePlayers).
@@ -144,7 +144,7 @@ func TestHandleStartGame_InvalidGameID(t *testing.T) {
 
 	// Ensure services are not called
 	mockGameStateService.AssertNotCalled(t, "UpdateGameState")
-	mockPlayerService.AssertNotCalled(t, "GetPlayers")
+	mockPlayerService.AssertNotCalled(t, "GetPlayersInGame")
 	mockPlayerService.AssertNotCalled(t, "AssignRandomTurns")
 	mockBoardService.AssertNotCalled(t, "ConfigureBoard")
 	mockMovementCardService.AssertNotCalled(t, "CreateMovementCardDeck")
@@ -194,7 +194,7 @@ func TestHandleStartGame_UpdateGameStateError(t *testing.T) {
 	// Verify only the necessary services were called
 	mockGameStateService.AssertExpectations(t)
 	mockGameStateService.AssertNotCalled(t, "UpdateGameState")
-	mockPlayerService.AssertNotCalled(t, "GetPlayers")
+	mockPlayerService.AssertNotCalled(t, "GetPlayersInGame")
 	mockPlayerService.AssertNotCalled(t, "AssignRandomTurns")
 	mockBoardService.AssertNotCalled(t, "ConfigureBoard")
 	mockMovementCardService.AssertNotCalled(t, "CreateMovementCardDeck")
@@ -217,7 +217,7 @@ func TestHandleStartGame_GetPlayersError(t *testing.T) {
 	// Mock responses
 	mockGameStateService.On("UpdateGameState", mock.Anything, gameID, gameState.PLAYING).
 		Return(nil)
-	mockPlayerService.On("GetPlayers", mock.Anything, gameID).
+	mockPlayerService.On("GetPlayersInGame", mock.Anything, gameID).
 		Return([]player.Player{}, errors.New("database error when fetching players"))
 
 	// Create handlers
@@ -268,7 +268,7 @@ func TestHandleStartGame_AssignRandomTurnError(t *testing.T) {
 	// Mock responses
 	mockGameStateService.On("UpdateGameState", mock.Anything, gameID, gameState.PLAYING).
 		Return(nil)
-	mockPlayerService.On("GetPlayers", mock.Anything, gameID).
+	mockPlayerService.On("GetPlayersInGame", mock.Anything, gameID).
 		Return([]player.Player{}, nil)
 
 	mockPlayerService.On("AssignRandomTurns", mock.Anything, []player.Player{}).
@@ -340,7 +340,7 @@ func TestHandleStartGame_UpdateCurrentPlayerError(t *testing.T) {
 	// Mock responses
 	mockGameStateService.On("UpdateGameState", mock.Anything, gameID, gameState.PLAYING).
 		Return(nil)
-	mockPlayerService.On("GetPlayers", mock.Anything, gameID).
+	mockPlayerService.On("GetPlayersInGame", mock.Anything, gameID).
 		Return(responsePlayers, nil)
 	mockPlayerService.On("AssignRandomTurns", mock.Anything, responsePlayers).
 		Return(responsePlayers[0].ID, nil)
@@ -405,7 +405,7 @@ func TestHandleStartGame_ConfigureBoardError(t *testing.T) {
 	// Mock responses
 	mockGameStateService.On("UpdateGameState", mock.Anything, gameID, gameState.PLAYING).
 		Return(nil)
-	mockPlayerService.On("GetPlayers", mock.Anything, gameID).
+	mockPlayerService.On("GetPlayersInGame", mock.Anything, gameID).
 		Return(responsePlayers, nil)
 	mockPlayerService.On("AssignRandomTurns", mock.Anything, responsePlayers).
 		Return(responsePlayers[0].ID, nil)
@@ -472,7 +472,7 @@ func TestHandleStartGame_CreateMovementCardDeckError(t *testing.T) {
 	// Mock responses
 	mockGameStateService.On("UpdateGameState", mock.Anything, gameID, gameState.PLAYING).
 		Return(nil)
-	mockPlayerService.On("GetPlayers", mock.Anything, gameID).
+	mockPlayerService.On("GetPlayersInGame", mock.Anything, gameID).
 		Return(responsePlayers, nil)
 	mockPlayerService.On("AssignRandomTurns", mock.Anything, responsePlayers).
 		Return(responsePlayers[0].ID, nil)
@@ -542,7 +542,7 @@ func TestHandleStartGame_CreateFigureCardDeckError(t *testing.T) {
 	// Mock responses
 	mockGameStateService.On("UpdateGameState", mock.Anything, gameID, gameState.PLAYING).
 		Return(nil)
-	mockPlayerService.On("GetPlayers", mock.Anything, gameID).
+	mockPlayerService.On("GetPlayersInGame", mock.Anything, gameID).
 		Return(responsePlayers, nil)
 	mockPlayerService.On("AssignRandomTurns", mock.Anything, responsePlayers).
 		Return(responsePlayers[0].ID, nil)

--- a/internal/handlers/handle_websocket.go
+++ b/internal/handlers/handle_websocket.go
@@ -43,7 +43,7 @@ func (h *WSHandlers) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	// Get the player to verify they belong to this game
 	if playerID != uuid.Nil {
-		player, err := h.playerService.GetPlayerByID(r.Context(), playerID)
+		player, err := h.playerService.GetPlayerByID(r.Context(), playerID, gameID)
 		if err != nil || player.GameID != gameID {
 			utils.RespondWithError(w, http.StatusForbidden, "Player not in this game", err)
 			return

--- a/internal/movementCard/service.go
+++ b/internal/movementCard/service.go
@@ -80,7 +80,7 @@ func (s *Service) CreateMovementCardDeck(ctx context.Context, gameID uuid.UUID) 
 	}
 
 	// assign 3 to each player
-	players, err := s.playerRepo.GetPlayers(ctx, gameID)
+	players, err := s.playerRepo.GetPlayersInGame(ctx, gameID)
 	if err != nil {
 		return fmt.Errorf("failed to get players: %w", err)
 	}

--- a/internal/player/interfaces.go
+++ b/internal/player/interfaces.go
@@ -10,16 +10,16 @@ import (
 type PlayerService interface {
 	CreatePlayer(ctx context.Context, playerData Player) (*Player, error)
 	DBToModel(ctx context.Context, dbPlayer database.Player) Player
-	GetPlayers(ctx context.Context, gameID uuid.UUID) ([]Player, error)
 	AssignRandomTurns(ctx context.Context, players []Player) (uuid.UUID, error)
 	CountPlayers(ctx context.Context, gameID uuid.UUID) (int, error)
-	GetPlayerByID(ctx context.Context, playerID uuid.UUID) (Player, error)
+	GetPlayerByID(ctx context.Context, gameID uuid.UUID, playerID uuid.UUID) (Player, error)
+	GetPlayersInGame(ctx context.Context, gameID uuid.UUID) ([]Player, error)
 }
 
 type PlayerRepository interface {
 	CreatePlayer(ctx context.Context, params database.CreatePlayerParams) (database.Player, error)
 	CountPlayers(ctx context.Context, gameID uuid.UUID) (int64, error)
-	GetPlayers(ctx context.Context, gameID uuid.UUID) ([]database.Player, error)
 	AssignTurnPlayer(ctx context.Context, params database.AssignTurnPlayerParams) error
-	GetPlayerByID(ctx context.Context, playerID uuid.UUID) (database.Player, error)
+	GetPlayerByID(ctx context.Context, params database.GetPlayerByIDParams) (database.Player, error)
+	GetPlayersInGame(ctx context.Context, gameID uuid.UUID) ([]database.Player, error)
 }

--- a/internal/player/mocks/player_repository_mock.go
+++ b/internal/player/mocks/player_repository_mock.go
@@ -24,8 +24,8 @@ func (m *MockPlayerRepository) CountPlayers(ctx context.Context, gameID uuid.UUI
 	return args.Get(0).(int64), args.Error(1)
 }
 
-// GetPlayers fetches all the players in a game
-func (m *MockPlayerRepository) GetPlayers(ctx context.Context, gameID uuid.UUID) ([]database.Player, error) {
+// GetPlayersInGame fetches all the players in a game
+func (m *MockPlayerRepository) GetPlayersInGame(ctx context.Context, gameID uuid.UUID) ([]database.Player, error) {
 	args := m.Called(ctx, gameID)
 	return args.Get(0).([]database.Player), args.Error(1)
 }
@@ -36,7 +36,7 @@ func (m *MockPlayerRepository) AssignTurnPlayer(ctx context.Context, params data
 	return args.Error(1)
 }
 
-func (m *MockPlayerRepository) GetPlayerByID(ctx context.Context, playerID uuid.UUID) (database.Player, error) {
-	args := m.Called(ctx, playerID)
+func (m *MockPlayerRepository) GetPlayerByID(ctx context.Context, params database.GetPlayerByIDParams) (database.Player, error) {
+	args := m.Called(ctx, params)
 	return args.Get(0).(database.Player), args.Error(1)
 }

--- a/internal/player/mocks/player_service_mock.go
+++ b/internal/player/mocks/player_service_mock.go
@@ -26,7 +26,7 @@ func (m *MockPlayerService) CreatePlayer(ctx context.Context, playerData player.
 	return args.Get(0).(*player.Player), args.Error(1)
 }
 
-func (m *MockPlayerService) GetPlayers(ctx context.Context, gameID uuid.UUID) ([]player.Player, error) {
+func (m *MockPlayerService) GetPlayersInGame(ctx context.Context, gameID uuid.UUID) ([]player.Player, error) {
 	args := m.Called(ctx, gameID)
 	return args.Get(0).([]player.Player), args.Error(1)
 }
@@ -42,7 +42,7 @@ func (m *MockPlayerService) CountPlayers(ctx context.Context, gameID uuid.UUID) 
 	return args.Get(0).(int), args.Error(1)
 }
 
-func (m *MockPlayerService) GetPlayerByID(ctx context.Context, playerID uuid.UUID) (player.Player, error) {
-	args := m.Called(ctx, playerID)
+func (m *MockPlayerService) GetPlayerByID(ctx context.Context, playerID uuid.UUID, gameID uuid.UUID) (player.Player, error) {
+	args := m.Called(ctx, playerID, gameID)
 	return args.Get(0).(player.Player), args.Error(1)
 }

--- a/internal/player/repository.go
+++ b/internal/player/repository.go
@@ -29,9 +29,9 @@ func (r *PostgresPlayerRepository) CountPlayers(ctx context.Context, gameID uuid
 	return r.queries.CountPlayers(ctx, gameID)
 }
 
-// GetPlayers fetches all the players in a game
-func (r *PostgresPlayerRepository) GetPlayers(ctx context.Context, gameID uuid.UUID) ([]database.Player, error) {
-	return r.queries.GetPlayers(ctx, gameID)
+// GetPlayersInGame fetches all the players in a game
+func (r *PostgresPlayerRepository) GetPlayersInGame(ctx context.Context, gameID uuid.UUID) ([]database.Player, error) {
+	return r.queries.GetPlayersInGame(ctx, gameID)
 }
 
 // AssignTurnPlayer sets the turn for the given player
@@ -40,6 +40,6 @@ func (r *PostgresPlayerRepository) AssignTurnPlayer(ctx context.Context, params 
 }
 
 // GetPlayerByID gets a player by the given id
-func (r *PostgresPlayerRepository) GetPlayerByID(ctx context.Context, playerID uuid.UUID) (database.Player, error) {
-	return r.queries.GetPlayerByID(ctx, playerID)
+func (r *PostgresPlayerRepository) GetPlayerByID(ctx context.Context, params database.GetPlayerByIDParams) (database.Player, error) {
+	return r.queries.GetPlayerByID(ctx, params)
 }

--- a/internal/player/service.go
+++ b/internal/player/service.go
@@ -43,8 +43,8 @@ func (s *Service) CreatePlayer(ctx context.Context, playerData Player) (*Player,
 	return &resultPlayer, nil
 }
 
-func (s *Service) GetPlayers(ctx context.Context, gameID uuid.UUID) ([]Player, error) {
-	players, err := s.playerRepo.GetPlayers(ctx, gameID)
+func (s *Service) GetPlayersInGame(ctx context.Context, gameID uuid.UUID) ([]Player, error) {
+	players, err := s.playerRepo.GetPlayersInGame(ctx, gameID)
 	if err != nil {
 		return nil, err
 	}
@@ -121,8 +121,11 @@ func (s *Service) CountPlayers(ctx context.Context, gameID uuid.UUID) (int, erro
 	return int(amountOfPlayers), nil
 }
 
-func (s *Service) GetPlayerByID(ctx context.Context, playerID uuid.UUID) (Player, error) {
-	playerDB, err := s.playerRepo.GetPlayerByID(ctx, playerID)
+func (s *Service) GetPlayerByID(ctx context.Context, playerID uuid.UUID, gameID uuid.UUID) (Player, error) {
+	playerDB, err := s.playerRepo.GetPlayerByID(ctx, database.GetPlayerByIDParams{
+		ID:     playerID,
+		GameID: gameID,
+	})
 	if err != nil {
 		return Player{}, err
 	}

--- a/sql/queries/players.sql
+++ b/sql/queries/players.sql
@@ -6,7 +6,7 @@ RETURNING *;
 -- name: CountPlayers :one
 SELECT COUNT(*) FROM players WHERE game_id = $1;
 
--- name: GetPlayers :many
+-- name: GetPlayersInGame :many
 SELECT *
 FROM players
 WHERE game_id=$1;
@@ -19,4 +19,4 @@ WHERE id=$1;
 -- name: GetPlayerByID :one
 SELECT *
 FROM players
-WHERE id=$1;
+WHERE game_id=$1 AND id=$2;


### PR DESCRIPTION
Added handlers for /players/{game_id} and /players/{game_id}/{player_id} endpoints, and their respective unit tests. I also changed the GetPlayers function name to GetPlayersInGame to be more consistent with the functionality of the function and add gameID parameter to GetPlayerByID to be sure that the fetched player belongs to the given gameID. 